### PR TITLE
Manual Validate- Empty Tag

### DIFF
--- a/blueprint.yml
+++ b/blueprint.yml
@@ -18,6 +18,8 @@ deploy:
       multi_az: false
       instance_class: db.t1.micro
       path_to_flyway_schema: web/src/main/resources/db/migration
+      tags:
+        council:
     beanstalk:
       type: beanstalk
       path_to_artifact: web/target/paas-aws-platform-demo-app-gauntc-web.war


### PR DESCRIPTION
Manually checking for case where the app is within the product council mapping list, but the tag is empty.  The experiment expects 'council: PlatformSvc-DPT-AWSPaaS' but recieves 'council:'.