### PR TITLE
Manual Validate- Bad Tag

### DIFF
--- a/blueprint.yml
+++ b/blueprint.yml
@@ -19,7 +19,7 @@ deploy:
       instance_class: db.t1.micro
       path_to_flyway_schema: web/src/main/resources/db/migration
       tags:
-        council:
+        council: badCouncil
     beanstalk:
       type: beanstalk
       path_to_artifact: web/target/paas-aws-platform-demo-app-gauntc-web.war


### PR DESCRIPTION
Manually checking for case where the app is within the product council mapping list, but the tag is incorrect.  The experiment expects 'council: PlatformSvc-DPT-AWSPaaS' but receives 'council: badCouncil'.