### PR TITLE
Renamed Name String Constant

### DIFF
--- a/web/src/main/java/org/familysearch/paas/db/EntityManagerFactoryFactory.java
+++ b/web/src/main/java/org/familysearch/paas/db/EntityManagerFactoryFactory.java
@@ -18,7 +18,7 @@ import org.familysearch.sas.schema.Sas;
 public class EntityManagerFactoryFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(EntityManagerFactoryFactory.class);
-  private static final String SAS_OBJECT_NAME = "paas-aws-platform-demo-app-dev-database-db";
+  private static final String SAS_OBJECT_NAME = "paas-aws-platform-demo-app-gauntc-dev-database-db";
   private static final ObjectRequester OBJECT_REQUESTER = new ObjectRequester();
 
   public EntityManagerFactory createEntityManagerFactory() throws IOException {


### PR DESCRIPTION
It looks like there was a string constant in one of the classes that I missed when changing the name of this app.  It has now been changed and hopefully will allow the build to go green.